### PR TITLE
Release v0.1.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,6 +4,9 @@ about: Use this template for tracking new features.
 ---
 
 # Feature
+| Title | Design | Spec |
+|---|---|---|
+||||
 
 # UI
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Multese",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "description": "Bring order to chaotic Pull Request description, by letting you utilize multiple Pull Request templates",
   "manifest_version": 2,
   "author": {
@@ -29,4 +29,3 @@
     "128": "icons/multese-logo-128.png"
   }
 }
-

--- a/src/components/IssueTemplateSelector.tsx
+++ b/src/components/IssueTemplateSelector.tsx
@@ -6,6 +6,7 @@ import qs = require('querystring')
 import { GithubRepository, IssueTemplateList } from '../@types/github'
 import { getTokenFromChromeStorage } from '../utils/getTokenFromChromeStorage'
 import { extractRepositoryIdentifier } from '../utils/extractRepositoryIdentifier'
+import { removeYamlFrontmatter } from '../utils/removeYamlFrontmatter'
 
 const getDefaultBranchNameQuery = require('../gqls/queries/getDefaultBranchName.gql')
 const getFileEntriesFromDefaultMainBranchByFilePathQuery = require('../gqls/queries/getFileEntriesFromDefaultMainBranchByFilePath.gql')
@@ -90,7 +91,7 @@ class IssueTemplateSelector extends React.Component<IssueTemplateSelectorProps, 
   applyTemplate({ target }) {
     const templateName = target.innerText
     const cardBodyTextArea: HTMLInputElement = document.querySelector('textarea#convert-card-body')
-    const templateBody = this.state.templates[templateName].replace(/-{3}(.|\n)*-{3}\n*/, '')
+    const templateBody = removeYamlFrontmatter(this.state.templates[templateName])
     if (cardBodyTextArea.value && !cardBodyTextArea.value.match(/\n$/)) {
       cardBodyTextArea.value += "\n"
     }

--- a/src/components/IssueTemplateSelector.tsx
+++ b/src/components/IssueTemplateSelector.tsx
@@ -105,7 +105,7 @@ class IssueTemplateSelector extends React.Component<IssueTemplateSelectorProps, 
           <label>Issue template</label>
           <br />
           <span className={classes.titleWarning}>
-            * YAML frontmatter (labels and assignees) will not applied
+            * YAML frontmatter (labels and assignees) will not be applied
           </span>
         </div>
         <div>

--- a/src/utils/removeYamlFrontmatter.ts
+++ b/src/utils/removeYamlFrontmatter.ts
@@ -1,0 +1,3 @@
+export const removeYamlFrontmatter = (str: string): string => {
+  return str.replace(/-{3}(.|\n)*(?<!\|)-{3}(?! *\|)\n*/, '')
+}


### PR DESCRIPTION
## Bugfix
- Fix typo
- Replace only meta-tag, not replacing tables

Before|After
-|-
![Screenshot from 2020-12-31 22-20-08](https://user-images.githubusercontent.com/29456740/103412092-e4d18700-4bb6-11eb-9499-a1f4b6019150.png)|![Screenshot from 2021-01-01 01-07-39](https://user-images.githubusercontent.com/29456740/103417383-d80c5d80-4bcd-11eb-83b4-245121a3c12b.png)

